### PR TITLE
enable extensibility for custom Salesforce REST API calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.force.api</groupId>
     <artifactId>force-rest-api</artifactId>
-    <version>0.0.21-SNAPSHOT</version>
+    <version>0.0.21-Z</version>
     <name>force-rest-api</name>
     <scm>
         <connection>scm:git:https://github.com/jesperfj/force-rest-api.git</connection>

--- a/src/main/java/com/force/api/ApiVersion.java
+++ b/src/main/java/com/force/api/ApiVersion.java
@@ -3,7 +3,8 @@ package com.force.api;
 public enum ApiVersion {
 	V24 ("v24.0"),
 	V23 ("v23.0"),
-	V22 ("v22.0"), 
+	V22 ("v22.0"),
+	V30 ("v30.0"),
 	DEFAULT_VERSION ("v23.0");
 
 	final String v;

--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -38,7 +38,7 @@ import java.util.Map.Entry;
  */
 public class ForceApi {
 
-	private static final ObjectMapper jsonMapper;
+	protected static final ObjectMapper jsonMapper;
 
 	static {
 		jsonMapper = new ObjectMapper();
@@ -303,11 +303,11 @@ public class ForceApi {
 		}
 	}
 	
-	private final String uriBase() {
+	protected final String uriBase() {
 		return(session.getApiEndpoint()+"/services/data/"+config.getApiVersion());
 	}
 	
-	private final HttpResponse apiRequest(HttpRequest req) {
+	protected final HttpResponse apiRequest(HttpRequest req) {
 		req.setAuthorization("OAuth "+session.getAccessToken());
 		HttpResponse res = Http.send(req);
 		if(res.getResponseCode()==401) {
@@ -405,7 +405,7 @@ public class ForceApi {
 	 * @param node 
 	 * @return
 	 */
-	private final JsonNode normalizeCompositeResponse(JsonNode node){
+	protected final JsonNode normalizeCompositeResponse(JsonNode node){
 		Iterator<Entry<String, JsonNode>> elements = node.getFields();
 		ObjectNode newNode = JsonNodeFactory.instance.objectNode();
 		Entry<String, JsonNode> currNode;

--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -302,7 +302,40 @@ public class ForceApi {
 			throw new ResourceException(e);
 		}
 	}
-	
+
+	/**
+	 * Make custom REST API call.
+	 * @param service service path to be called - i.e. /process/approvals/
+	 * @param httpMethod HTTP method name - i.e. POST
+	 * @param input input object
+	 * @param expectsCode expected HTTP code
+	 * @param outputClass class of the response
+	 * @return marshaled response
+	 */
+	protected <O,I> O call(final String service, final String httpMethod, final I input,
+						   final int expectsCode, final Class<O> outputClass) {
+		try {
+			final byte[] contentBytes = jsonMapper.writeValueAsBytes(input);
+			final HttpRequest httpRequest = new HttpRequest()
+					.url(uriBase() + service)
+					.method(httpMethod)
+					.header("Accept", "application/json")
+					.header("Content-Type", "application/json")
+					.content(contentBytes);
+			if (expectsCode > 0) {
+				httpRequest.expectsCode(expectsCode);
+			}
+			final HttpResponse response = apiRequest(httpRequest);
+			return new ResourceRepresentation(response).as(outputClass);
+		} catch (JsonGenerationException e) {
+			throw new ResourceException(e);
+		} catch (JsonMappingException e) {
+			throw new ResourceException(e);
+		} catch (IOException e) {
+			throw new ResourceException(e);
+		}
+	}
+
 	protected final String uriBase() {
 		return(session.getApiEndpoint()+"/services/data/"+config.getApiVersion());
 	}


### PR DESCRIPTION
sometimes Salesforce exposes custom REST API calls - making the methods protected makes possible to create RestApi method implementations for custom Salesforce REST API calls