### PR TITLE
Add apiSecurityToken check to the soap login flow.  If it exists then ap...

### DIFF
--- a/src/main/java/com/force/api/ApiConfig.java
+++ b/src/main/java/com/force/api/ApiConfig.java
@@ -12,6 +12,7 @@ public class ApiConfig {
 	String clientId;
 	String clientSecret;
 	String redirectURI;
+	String apiSecurityToken;
 
 	public ApiConfig clone() {
 		return new ApiConfig()
@@ -21,7 +22,8 @@ public class ApiConfig {
 			.setLoginEndpoint(loginEndpoint)
 			.setClientId(clientId)
 			.setClientSecret(clientSecret)
-			.setRedirectURI(redirectURI);
+			.setRedirectURI(redirectURI)
+			.setApiSecurityToken(apiSecurityToken);
 	}
 	
 	public ApiConfig setForceURL(String url) {
@@ -82,6 +84,11 @@ public class ApiConfig {
 		return this;
 	}
 
+	public ApiConfig setApiSecurityToken(String value) {
+		apiSecurityToken = value;
+		return this;
+	}
+
 	public String getUsername() {
 		return username;
 	}
@@ -106,10 +113,9 @@ public class ApiConfig {
 		return redirectURI;
 	}
 
+	public String getApiSecurityToken() { return apiSecurityToken; }
+
 	public ApiVersion getApiVersion() {
 		return apiVersion;
 	}
-
-
-	
 }

--- a/src/main/java/com/force/api/Auth.java
+++ b/src/main/java/com/force/api/Auth.java
@@ -53,6 +53,10 @@ public class Auth {
 	static public final ApiSession soaploginPasswordFlow(ApiConfig c) {
 		if(c.getUsername()==null) throw new IllegalStateException("username cannot be null");
 		if(c.getPassword()==null) throw new IllegalStateException("password cannot be null");
+		StringBuilder password = new StringBuilder(c.getPassword());
+		if (c.getApiSecurityToken() != null){
+			password.append(c.getApiSecurityToken());
+		}
 		try {
 			URL url = new URL(c.getLoginEndpoint()+"/services/Soap/u/33.0");
 			HttpURLConnection conn = (HttpURLConnection) url.openConnection();
@@ -68,7 +72,7 @@ public class Auth {
 					"    <env:Body>\n"+
 			        "        <n1:login xmlns:n1=\"urn:partner.soap.sforce.com\">\n"+
 			        "            <n1:username>"+c.getUsername()+"</n1:username>\n"+
-			        "            <n1:password>"+c.getPassword()+"</n1:password>\n"+
+			        "            <n1:password>"+password.toString()+"</n1:password>\n"+
 			        "        </n1:login>\n"+
 			        "    </env:Body>\n"+
 			        "</env:Envelope>\n").getBytes("UTF-8");

--- a/src/test/java/com/force/api/AuthTest.java
+++ b/src/test/java/com/force/api/AuthTest.java
@@ -12,7 +12,8 @@ public class AuthTest {
 	public void testSoapLogin() {
 		ForceApi api = new ForceApi(new ApiConfig()
 			.setUsername(Fixture.get("username"))
-			.setPassword(Fixture.get("password")));
+			.setPassword(Fixture.get("password"))
+			.setApiSecurityToken(Fixture.get("apiSecurityToken")));
 
 		assertNotNull(api.session);
 		assertNotNull(api.session.accessToken);
@@ -71,7 +72,8 @@ public class AuthTest {
 	public void testExistingValidAccessToken() {
 		ApiConfig c = new ApiConfig()
 			.setUsername(Fixture.get("username"))
-			.setPassword(Fixture.get("password"));
+			.setPassword(Fixture.get("password"))
+			.setApiSecurityToken(Fixture.get("apiSecurityToken"));
 
 		ForceApi api = new ForceApi(c);
 

--- a/src/test/java/com/force/api/QueryTest.java
+++ b/src/test/java/com/force/api/QueryTest.java
@@ -20,7 +20,8 @@ public class QueryTest {
 	public void init() {
 		api = new ForceApi(new ApiConfig()
 		.setUsername(Fixture.get("username"))
-		.setPassword(Fixture.get("password")));
+		.setPassword(Fixture.get("password"))
+        .setApiSecurityToken(Fixture.get("apiSecurityToken")));
 	}
 	
 	@Test

--- a/src/test/resources/test.properties.sample
+++ b/src/test/resources/test.properties.sample
@@ -3,5 +3,5 @@ username=user@domain.com
 password=secretcode
 clientId=long-alphanumeric-sequence
 clientSecret=shorter-numeric-sequence
+apiSecurityToken=security-token-for-soap-requests
 redirectURI=http://localhost:5000/_auth
-


### PR DESCRIPTION
Salesforce by default now requires a Token for API calls by default since version 31.

https://www.salesforce.com/developer/docs/api/Content/sforce_api_concepts_security.htm#topic-title_login_token

My developer sandbox didn't have this disabled and therefore all the SOAP API calls were failing with 500 errors and the Salesforce Login saying 
`Failed Api Security Token required.`

I figured instead of disabling the settings or adding my IP to the trusted list, I'd add a new ApiConfig property (apiSecurityToken).

If this token is provided it will append it to the end of the password for the SOAP Login flow. Per documentation

>Salesforce checks the IP address from which the client application is logging in, and blocks logins from unknown IP addresses. For a blocked login via the API, Salesforce returns a login fault. Then, the user must add their security token to the end of their password in order to log in. A security token is an automatically-generated key from Salesforce. For example, if a user's password is mypassword, and their security token is XXXXXXXXXX, then the user must enter mypasswordXXXXXXXXXX to log in. Users can obtain their security token by changing their password or resetting their security token via the Salesforce user interface. When a user changes their password or resets their security token, Salesforce sends a new security token to the email address on the user's Salesforce record. The security token is valid until a user resets their security token, changes their password, or has their password reset. When the security token is invalid, the user must repeat the login process to log in. To avoid this, the administrator can make sure the client's IP address is added to the organization's list of trusted IP addresses. For more information, see “Security Token” in the in the SOAP API Developer's Guide.







