### PR TITLE
Support for deleting an SObject by external ID

### DIFF
--- a/src/main/java/com/force/api/DeleteResult.java
+++ b/src/main/java/com/force/api/DeleteResult.java
@@ -1,0 +1,3 @@
+package com.force.api;
+
+public enum DeleteResult { DELETED, NOT_FOUND }

--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -164,6 +164,27 @@ public class ForceApi {
 		);
 	}
 
+	public DeleteResult deleteSObject(String type, String externalIdField, String externalIdValue) {
+		try {
+			HttpResponse res =
+				apiRequest(new HttpRequest()
+					.url(uriBase()+"/sobjects/"+type+"/"+externalIdField+"/"+URLEncoder.encode(externalIdValue,"UTF-8"))
+					.method("DELETE")
+					.header("Accept", "application/json")
+				);
+			if(res.getResponseCode()==204) {
+				return DeleteResult.DELETED;
+			} else {
+				System.out.println("Code: "+res.getResponseCode());
+				System.out.println("Message: "+res.getString());
+				throw new RuntimeException();
+			}
+
+		} catch (IOException e) {
+			throw new ResourceException(e);
+		}
+	}
+
 	public CreateOrUpdateResult createOrUpdateSObject(String type, String externalIdField, String externalIdValue, Object sObject) {
 		try {
 			// See createSObject for note on streaming ambition


### PR DESCRIPTION
Hi Jesper,

First of all, many thanks for this very helpful library.

We added support for deleting an SObject directly by external ID, hence this PR. This is just to get the ball rolling on the subject, as there's a number of things to discuss before merging.

Right now, when trying to delete an inexistent SObject, we use the classic ApiException system to be completely homogeneous with the rest of the code. You'll see that in the DeleteResult enum, we also hinted at providing support directly in the result instead of throwing an Exception. I've got a mixed feeling about this, so need your guidance on the style you want to enforce.

For example, in our use case, right now we catch the ApiException and check for 404 error codes in the caller. The drawback is that the current code will print stuff to stdout (we did this to do exactly like in createSObject) on 404s.

Let me know, then I can rework this patch, and provide unit tests and docs.
Cheers !
