### PR TITLE
enable extensibility for custom Salesforce REST API calls creation

### DIFF
--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -41,7 +41,7 @@ import java.util.Map.Entry;
  */
 public class ForceApi {
 
-	private static final ObjectMapper jsonMapper;
+	protected static final ObjectMapper jsonMapper;
 
 	private static final Logger logger = LoggerFactory.getLogger(ForceApi.class);
 
@@ -317,11 +317,11 @@ public class ForceApi {
 		}
 	}
 	
-	private final String uriBase() {
+	protected final String uriBase() {
 		return(session.getApiEndpoint()+"/services/data/"+config.getApiVersionString());
 	}
 	
-	private final HttpResponse apiRequest(HttpRequest req) {
+	protected final HttpResponse apiRequest(HttpRequest req) {
 		req.setAuthorization("Bearer "+session.getAccessToken());
 		HttpResponse res = Http.send(req);
 		if(res.getResponseCode()==401) {
@@ -419,7 +419,7 @@ public class ForceApi {
 	 * @param node 
 	 * @return
 	 */
-	private final JsonNode normalizeCompositeResponse(JsonNode node){
+	protected final JsonNode normalizeCompositeResponse(JsonNode node){
 		Iterator<Entry<String, JsonNode>> elements = node.fields();
 		ObjectNode newNode = JsonNodeFactory.instance.objectNode();
 		Entry<String, JsonNode> currNode;

--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -316,7 +316,40 @@ public class ForceApi {
 			throw new ResourceException(e);
 		}
 	}
-	
+
+	/**
+	 * Make custom REST API call.
+	 * @param service service path to be called - i.e. /process/approvals/
+	 * @param httpMethod HTTP method name - i.e. POST
+	 * @param input input object
+	 * @param expectsCode expected HTTP code
+	 * @param outputClass class of the response
+	 * @return marshaled response
+	 */
+	protected <O,I> O call(final String service, final String httpMethod, final I input,
+						   final int expectsCode, final Class<O> outputClass) {
+		try {
+			final byte[] contentBytes = jsonMapper.writeValueAsBytes(input);
+			final HttpRequest httpRequest = new HttpRequest()
+					.url(uriBase() + service)
+					.method(httpMethod)
+					.header("Accept", "application/json")
+					.header("Content-Type", "application/json")
+					.content(contentBytes);
+			if (expectsCode > 0) {
+				httpRequest.expectsCode(expectsCode);
+			}
+			final HttpResponse response = apiRequest(httpRequest);
+			return new ResourceRepresentation(response).as(outputClass);
+		} catch (JsonGenerationException e) {
+			throw new ResourceException(e);
+		} catch (JsonMappingException e) {
+			throw new ResourceException(e);
+		} catch (IOException e) {
+			throw new ResourceException(e);
+		}
+	}
+
 	protected final String uriBase() {
 		return(session.getApiEndpoint()+"/services/data/"+config.getApiVersionString());
 	}


### PR DESCRIPTION
Sometimes Salesforce exposes custom REST API calls - making the methods protected makes possible to create RestApi method implementations for custom Salesforce REST API calls. For example we are using the forked and changed api as a base for pulling SF reports via REST API calls. 

This is an updated version of the old pull request #18.