### PR TITLE
Generic get, post, put, patch and delete REST methods

### DIFF
--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -73,6 +73,45 @@ public class ForceApi {
 
 	}
 
+	public ResourceRepresentation get(String path) {
+		return new ResourceRepresentation(apiRequest(new HttpRequest()
+				.url(uriBase()+path)
+				.method("GET")
+				.header("Accept", "application/json")));
+	}
+
+	public ResourceRepresentation get(String path, String query) {
+		return new ResourceRepresentation(apiRequest(new HttpRequest()
+				.url(uriBase()+path+"?"+query)
+				.method("GET")
+				.header("Accept", "application/json")));
+	}
+
+	/**
+	 * sends a custom REST API POST request
+	 *
+	 * @param path     service path to be called - i.e. /process/approvals/
+	 * @param input    this object will be serialized as JSON and sent in tbe body of the request
+	 * @param expectedCode expected HTTP code. Set to -1 if code shouldn't be checked.
+	 * @return response from API wrapped in a ResourceRepresentation for multiple deserialization options
+	 */
+	public ResourceRepresentation post(String path, Object input, int expectedCode) {
+		try {
+			return new ResourceRepresentation(apiRequest(new HttpRequest()
+					.url(uriBase() + path)
+					.method("POST")
+					.header("Accept", "application/json")
+					.header("Content-Type", "application/json")
+					.expectsCode(expectedCode)
+					.content(jsonMapper.writeValueAsBytes(input))));
+		} catch (JsonGenerationException e) {
+			throw new ResourceException(e);
+		} catch (JsonMappingException e) {
+			throw new ResourceException(e);
+		} catch (IOException e) {
+			throw new ResourceException(e);
+		}
+	}
 
 	public Identity getIdentity() {
 		try {

--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -118,7 +118,7 @@ public class ForceApi {
 	}
 
 	/**
-	 * sends a custom REST API PUT request
+	 * sends a custom REST API PUT request (no test for this method yet).
 	 *
 	 * @param path     service path to be called - i.e. /process/approvals/
 	 * @param input    this object will be serialized as JSON and sent in tbe body of the request

--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -113,8 +113,8 @@ public class ForceApi {
 	 * @param expectedCode expected HTTP code. Set to -1 if code shouldn't be checked.
 	 * @return response from API wrapped in a ResourceRepresentation for multiple deserialization options
 	 */
-	public ResourceRepresentation post(String path, Object input, int expectedCode) {
-		return request("POST", path, input, expectedCode);
+	public ResourceRepresentation post(String path, Object input) {
+		return request("POST", path, input, 201);
 	}
 
 	/**
@@ -122,11 +122,10 @@ public class ForceApi {
 	 *
 	 * @param path     service path to be called - i.e. /process/approvals/
 	 * @param input    this object will be serialized as JSON and sent in tbe body of the request
-	 * @param expectedCode expected HTTP code. Set to -1 if code shouldn't be checked.
 	 * @return response from API wrapped in a ResourceRepresentation for multiple deserialization options
 	 */
-	public ResourceRepresentation put(String path, Object input, int expectedCode) {
-		return request("PUT", path, input, expectedCode);
+	public ResourceRepresentation put(String path, Object input) {
+		return request("PUT", path, input, 200);
 	}
 
 	/**
@@ -137,9 +136,9 @@ public class ForceApi {
 	 * @param expectedCode expected HTTP code. Set to -1 if code shouldn't be checked.
 	 * @return response from API wrapped in a ResourceRepresentation for multiple deserialization options
 	 */
-	public ResourceRepresentation patch(String path, Object input, int expectedCode) {
+	public ResourceRepresentation patch(String path, Object input) {
 		char sep = path.contains("?") ? '&' : '?';
-		return request("POST", path+sep+"_HttpMethod=PATCH", input, expectedCode);
+		return request("POST", path+sep+"_HttpMethod=PATCH", input, 200);
 	}
 
 	public ResourceRepresentation request(String method, String path, Object input, int expectedCode) {

--- a/src/main/java/com/force/api/http/Http.java
+++ b/src/main/java/com/force/api/http/Http.java
@@ -17,29 +17,35 @@ import java.net.URL;
 
 public class Http {
 
-	static {
-		try {
-			Field methodsField = HttpURLConnection.class.getDeclaredField("methods");
-			methodsField.setAccessible(true);
-			// get the methods field modifiers
-			Field modifiersField = Field.class.getDeclaredField("modifiers");
-			// bypass the "private" modifier
-			modifiersField.setAccessible(true);
-
-			// remove the "final" modifier
-			modifiersField.setInt(methodsField, methodsField.getModifiers() & ~Modifier.FINAL);
-
-         	/* valid HTTP methods */
-			String[] methods = {
-					"GET", "POST", "HEAD", "OPTIONS", "PUT", "DELETE", "TRACE", "PATCH"
-			};
-			// set the new methods - including patch
-			methodsField.set(null, methods);
-
-		} catch (Throwable e) {
-			e.printStackTrace();
-		}
-	}
+	// This magic piece of code is from http://stackoverflow.com/a/39641592/82236
+	// It addresses the unfathomable reality that JDK doesn't support PATCH.
+	// But it messes with the standard library at runtime, so I am not feeling great about
+	// doing it in a library that will coexist with other code in the same runtime. Leaving it
+	// in comments for now.
+	//
+	//	static {
+	//		try {
+	//			Field methodsField = HttpURLConnection.class.getDeclaredField("methods");
+	//			methodsField.setAccessible(true);
+	//			// get the methods field modifiers
+	//			Field modifiersField = Field.class.getDeclaredField("modifiers");
+	//			// bypass the "private" modifier
+	//			modifiersField.setAccessible(true);
+	//
+	//			// remove the "final" modifier
+	//			modifiersField.setInt(methodsField, methodsField.getModifiers() & ~Modifier.FINAL);
+	//
+	//         	/* valid HTTP methods */
+	//			String[] methods = {
+	//					"GET", "POST", "HEAD", "OPTIONS", "PUT", "DELETE", "TRACE", "PATCH"
+	//			};
+	//			// set the new methods - including patch
+	//			methodsField.set(null, methods);
+	//
+	//		} catch (Throwable e) {
+	//			e.printStackTrace();
+	//		}
+	//	}
 
 	static final Logger logger = LoggerFactory.getLogger(Http.class);
 	

--- a/src/main/java/com/force/api/http/Http.java
+++ b/src/main/java/com/force/api/http/Http.java
@@ -8,12 +8,38 @@ import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 
 
 public class Http {
+
+	static {
+		try {
+			Field methodsField = HttpURLConnection.class.getDeclaredField("methods");
+			methodsField.setAccessible(true);
+			// get the methods field modifiers
+			Field modifiersField = Field.class.getDeclaredField("modifiers");
+			// bypass the "private" modifier
+			modifiersField.setAccessible(true);
+
+			// remove the "final" modifier
+			modifiersField.setInt(methodsField, methodsField.getModifiers() & ~Modifier.FINAL);
+
+         	/* valid HTTP methods */
+			String[] methods = {
+					"GET", "POST", "HEAD", "OPTIONS", "PUT", "DELETE", "TRACE", "PATCH"
+			};
+			// set the new methods - including patch
+			methodsField.set(null, methods);
+
+		} catch (Throwable e) {
+			e.printStackTrace();
+		}
+	}
 
 	static final Logger logger = LoggerFactory.getLogger(Http.class);
 	

--- a/src/test/java/com/force/api/AuthTest.java
+++ b/src/test/java/com/force/api/AuthTest.java
@@ -71,7 +71,9 @@ public class AuthTest {
 
 		assertNotNull(api.session);
 		assertNotNull(api.session.accessToken);
+		System.out.println(api.session.accessToken);
 		assertNotNull(api.session.apiEndpoint);
+		System.out.println(api.session.apiEndpoint);
 
 	}
 

--- a/src/test/java/com/force/api/CurlHelper.java
+++ b/src/test/java/com/force/api/CurlHelper.java
@@ -1,0 +1,21 @@
+package com.force.api;
+
+import org.junit.Test;
+
+/**
+ * Created by jjoergensen on 2/26/17.
+ */
+
+public class CurlHelper {
+
+    @Test
+    public void curlHelper() {
+        ForceApi api = new ForceApi(new ApiConfig()
+                .setUsername(Fixture.get("username"))
+                .setPassword(Fixture.get("password"))
+                .setClientId(Fixture.get("clientId"))
+                .setClientSecret(Fixture.get("clientSecret")));
+
+        System.out.println(api.curlHelper());
+    }
+}

--- a/src/test/java/com/force/api/chatter/ChatterFeed.java
+++ b/src/test/java/com/force/api/chatter/ChatterFeed.java
@@ -1,0 +1,51 @@
+package com.force.api.chatter;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Created by jjoergensen on 2/25/17.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChatterFeed {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class MessageSegment {
+        public String type;
+        public String text;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Body {
+        public List<MessageSegment> messageSegments;
+        public String text;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Actor {
+
+        public String displayName;
+        public String id;
+
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class FeedItem {
+
+        public Actor actor;
+        public Body body;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class FeedItemInput {
+
+        public String feedElementType;
+        public String subjectId;
+        public Body body;
+    }
+
+    public List<FeedItem> elements;
+
+}

--- a/src/test/java/com/force/api/chatter/ChatterFeed.java
+++ b/src/test/java/com/force/api/chatter/ChatterFeed.java
@@ -34,6 +34,7 @@ public class ChatterFeed {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class FeedItem {
 
+        public String id;
         public Actor actor;
         public Body body;
     }

--- a/src/test/java/com/force/api/chatter/ChatterTest.java
+++ b/src/test/java/com/force/api/chatter/ChatterTest.java
@@ -1,0 +1,49 @@
+package com.force.api.chatter;
+
+import com.force.api.ApiConfig;
+import com.force.api.Fixture;
+import com.force.api.ForceApi;
+import com.force.api.Identity;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by jjoergensen on 2/25/17.
+ */
+public class ChatterTest {
+    static final String TEST_NAME = "force-rest-api basic chatter test";
+
+    @Test
+    public void rawRestTest() {
+
+        ForceApi api = new ForceApi(new ApiConfig()
+                .setUsername(Fixture.get("username"))
+                .setPassword(Fixture.get("password"))
+                .setClientId(Fixture.get("clientId"))
+                .setClientSecret(Fixture.get("clientSecret")));
+
+        ChatterFeed feed = api.get("/chatter/feeds/user-profile/me/feed-elements").as(ChatterFeed.class);
+
+        Identity me = api.getIdentity();
+        System.out.println(me.getUserId());
+
+        assertEquals(feed.elements.get(0).actor.id, me.getUserId());
+
+        ChatterFeed.FeedItemInput newItem = new ChatterFeed.FeedItemInput();
+        newItem.subjectId = me.getUserId();
+        newItem.feedElementType = "FeedItem";
+        newItem.body = new ChatterFeed.Body();
+        newItem.body.messageSegments = new ArrayList<ChatterFeed.MessageSegment>();
+        ChatterFeed.MessageSegment segment = new ChatterFeed.MessageSegment();
+        segment.type = "text";
+        segment.text = "Hi from Chatter API";
+        newItem.body.messageSegments.add(segment);
+
+        ChatterFeed.FeedItem resp = api.post("/chatter/feed-elements", newItem, 201).as(ChatterFeed.FeedItem.class);
+        System.out.println(resp.actor.displayName+" just posted "+resp.body.text);
+        assertEquals(segment.text, resp.body.text);
+    }
+}

--- a/src/test/java/com/force/api/chatter/ChatterTest.java
+++ b/src/test/java/com/force/api/chatter/ChatterTest.java
@@ -40,7 +40,7 @@ public class ChatterTest {
         segment.text = "Hi from Chatter API";
         newItem.body.messageSegments.add(segment);
 
-        ChatterFeed.FeedItem resp = api.post("/chatter/feed-elements", newItem, 201).as(ChatterFeed.FeedItem.class);
+        ChatterFeed.FeedItem resp = api.post("/chatter/feed-elements", newItem).as(ChatterFeed.FeedItem.class);
         System.out.println(resp.actor.displayName+" just posted "+resp.body.text);
         assertEquals(segment.text, resp.body.text);
 
@@ -52,7 +52,7 @@ public class ChatterTest {
         updatedSegment.text = "I changed my mind";
         updatedItem.body.messageSegments.add(updatedSegment);
 
-        ChatterFeed.FeedItem updatedresp = api.patch("/chatter/feed-elements/" + resp.id, updatedItem, 200).as(ChatterFeed.FeedItem.class);
+        ChatterFeed.FeedItem updatedresp = api.patch("/chatter/feed-elements/" + resp.id, updatedItem).as(ChatterFeed.FeedItem.class);
         System.out.println(resp.actor.displayName+" just updated to "+updatedresp.body.text);
         assertEquals(updatedSegment.text, updatedresp.body.text);
 

--- a/src/test/java/com/force/api/chatter/ChatterTest.java
+++ b/src/test/java/com/force/api/chatter/ChatterTest.java
@@ -1,14 +1,12 @@
 package com.force.api.chatter;
 
-import com.force.api.ApiConfig;
-import com.force.api.Fixture;
-import com.force.api.ForceApi;
-import com.force.api.Identity;
+import com.force.api.*;
 import org.junit.Test;
 
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Created by jjoergensen on 2/25/17.
@@ -17,7 +15,7 @@ public class ChatterTest {
     static final String TEST_NAME = "force-rest-api basic chatter test";
 
     @Test
-    public void rawRestTest() {
+    public void chatterCRUDTest() {
 
         ForceApi api = new ForceApi(new ApiConfig()
                 .setUsername(Fixture.get("username"))
@@ -45,5 +43,24 @@ public class ChatterTest {
         ChatterFeed.FeedItem resp = api.post("/chatter/feed-elements", newItem, 201).as(ChatterFeed.FeedItem.class);
         System.out.println(resp.actor.displayName+" just posted "+resp.body.text);
         assertEquals(segment.text, resp.body.text);
+
+        ChatterFeed.FeedItemInput updatedItem = new ChatterFeed.FeedItemInput();
+        updatedItem.body = new ChatterFeed.Body();
+        updatedItem.body.messageSegments = new ArrayList<ChatterFeed.MessageSegment>();
+        ChatterFeed.MessageSegment updatedSegment = new ChatterFeed.MessageSegment();
+        updatedSegment.type = "text";
+        updatedSegment.text = "I changed my mind";
+        updatedItem.body.messageSegments.add(updatedSegment);
+
+        ChatterFeed.FeedItem updatedresp = api.patch("/chatter/feed-elements/" + resp.id, updatedItem, 200).as(ChatterFeed.FeedItem.class);
+        System.out.println(resp.actor.displayName+" just updated to "+updatedresp.body.text);
+        assertEquals(updatedSegment.text, updatedresp.body.text);
+
+
+//        try {
+//            api.delete("/chatter/feed-elements/" + resp.id);
+//        } catch(ResourceException e){
+//                fail("Delete failed unexpectedly: "+e);
+//        }
     }
 }


### PR DESCRIPTION
This code adds new public methods to address the needs in #37 without resorting to subclassing.

@zacheusz and @cswendrowski, let me know what you think. I am shooting for having explicit methods for get, post, put, delete and patch instead of taking these verbs as parameters.

For now, it is only supporting JSON request contents andis  always expecting a JSON body in the response. This can be made more flexible at a later point.
