### PR TITLE
remove response code checks from delete, post, put, patch

### DIFF
--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -101,7 +101,6 @@ public class ForceApi {
 		return new ResourceRepresentation(apiRequest(new HttpRequest()
 				.url(uriBase() + path)
 				.method("DELETE")
-				.expectsCode(204)
 				.header("Accept", "application/json")));
 	}
 
@@ -113,7 +112,7 @@ public class ForceApi {
 	 * @return response from API wrapped in a ResourceRepresentation for multiple deserialization options
 	 */
 	public ResourceRepresentation post(String path, Object input) {
-		return request("POST", path, input, 201);
+		return request("POST", path, input);
 	}
 
 	/**
@@ -124,7 +123,7 @@ public class ForceApi {
 	 * @return response from API wrapped in a ResourceRepresentation for multiple deserialization options
 	 */
 	public ResourceRepresentation put(String path, Object input) {
-		return request("PUT", path, input, 200);
+		return request("PUT", path, input);
 	}
 
 	/**
@@ -136,17 +135,16 @@ public class ForceApi {
 	 */
 	public ResourceRepresentation patch(String path, Object input) {
 		char sep = path.contains("?") ? '&' : '?';
-		return request("POST", path+sep+"_HttpMethod=PATCH", input, 200);
+		return request("POST", path+sep+"_HttpMethod=PATCH", input);
 	}
 
-	public ResourceRepresentation request(String method, String path, Object input, int expectedCode) {
+	public ResourceRepresentation request(String method, String path, Object input) {
 		try {
 			return new ResourceRepresentation(apiRequest(new HttpRequest()
 					.url(uriBase() + path)
 					.method(method)
 					.header("Accept", "application/json")
 					.header("Content-Type", "application/json")
-					.expectsCode(expectedCode)
 					.content(jsonMapper.writeValueAsBytes(input))));
 		} catch (JsonGenerationException e) {
 			throw new ResourceException(e);

--- a/src/main/java/com/force/api/ResourceRepresentation.java
+++ b/src/main/java/com/force/api/ResourceRepresentation.java
@@ -62,4 +62,12 @@ public class ResourceRepresentation {
 		}
 	}
 
+	/**
+	 *
+	 * @return the HTTP response code of the underlying request if it was between 200 and 299. Any code outside of that
+	 * range will result in an ApiException being thrown before a ResourceRepresentation is instantiated.
+	 */
+	public int getResponseCode() {
+		return response.getResponseCode();
+	}
 }


### PR DESCRIPTION
Based on the fact that POST to Chatter resources and POST to approval process resources return different response codes (201 and 200), it's clear that it's too risky to assume a specific response code.

This pull request removes the response code check and makes the response code available in ResourceRepresentation for the user to perform the check on their own.

Note that response codes outside the range of 200 and 299 (except for 401 which triggers a session refresh and retry) will still be considered unexpected behavior. They will result in an ApiException being thrown.

@zacheusz let me know what you think.

It has been raised before, by @pmq in #26, that 404s (resource not found) should not be considered unexpected behavior. If this pull request is merged, I will consider how to use a similar strategy to handle 404s without throwing exceptions. There are a couple of tricky questions though. 1) It's a change of behavior that might break existing users. 2) Should 404 be dealt with specifically, or should the whole response code checking be rejiggered? Those questions will be dealt with in a future pull request.

