### PR TITLE
Issue #48: New ApiConfig option to allow sending of null values by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,20 @@ This assumes you have an Account class defined with proper Jackson deserializati
 
     QueryResult<Account> res = api.query("SELECT id FROM Account WHERE name LIKE 'Test account%'", Account.class);
 
+### JSON serialization
+
+By default, ForceApi will remove all properties with value null from the payload before it gets sent to Salesforce for an update. If you would like more control over this, you can override that default:
+
+    ForceApi api = new ForceApi(new ApiConfig()
+    				.setIncludeNullValues(true));
+
+This setting will let you control for each field if you want to send its null values (e.g. to clear existing values) or not. You can then e.g. exclude null values on an individual field basis by using Jackson annotations:
+
+    // ... your data container class representing an SObject structure
+    @JsonProperty("isRestricted__c") 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    Boolean isRestricted;
+
 ## Working with API versions
 
 You can inspect supported API versions and get more detailed info for each version using `SupportedVersions`:

--- a/src/main/java/com/force/api/ApiConfig.java
+++ b/src/main/java/com/force/api/ApiConfig.java
@@ -13,6 +13,7 @@ public class ApiConfig {
 	String clientId;
 	String clientSecret;
 	String redirectURI;
+	boolean includeNullValues = false;
 	SessionRefreshListener sessionRefreshListener;
 
 	public ApiConfig clone() {
@@ -90,6 +91,12 @@ public class ApiConfig {
 		clientSecret = value;
 		return this;
 	}
+	
+	public ApiConfig setIncludeNullValues(boolean includeNullValues) {
+		this.includeNullValues = includeNullValues;
+		return this;
+	}
+	
 	public ApiConfig setSessionRefreshListener(SessionRefreshListener value) {
 		sessionRefreshListener = value;
 		return this;
@@ -117,6 +124,10 @@ public class ApiConfig {
 	
 	public String getRedirectURI() {
 		return redirectURI;
+	}
+	
+	public boolean includeNullValues() {
+		return includeNullValues;
 	}
 
 	public SessionRefreshListener getSessionRefreshListener() { return sessionRefreshListener; }

--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -41,15 +41,10 @@ import java.util.Map.Entry;
  */
 public class ForceApi {
 
-	private static final ObjectMapper jsonMapper;
+	private final ObjectMapper jsonMapper;
 
 	private static final Logger logger = LoggerFactory.getLogger(ForceApi.class);
-
-	static {
-		jsonMapper = new ObjectMapper();
-		jsonMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-	}
-
+	
 	final ApiConfig config;
 	ApiSession session;
 	private boolean autoRenew = false;
@@ -57,6 +52,7 @@ public class ForceApi {
 	public ForceApi(ApiConfig config, ApiSession session) {
 		this.config = config;
 		this.session = session;
+		this.jsonMapper = createJsonMapper(config);
 		if(session.getRefreshToken()!=null) {
 			autoRenew = true;
 		}
@@ -70,7 +66,15 @@ public class ForceApi {
 		config = apiConfig;
 		session = Auth.authenticate(apiConfig);
 		autoRenew  = true;
-
+		this.jsonMapper = createJsonMapper(apiConfig);
+	}
+	
+	private ObjectMapper createJsonMapper(ApiConfig config) {
+		final ObjectMapper newMapper = new ObjectMapper();
+		if(config.includeNullValues() != true) {
+			newMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+		}
+		return newMapper;
 	}
 
 	public ApiSession getSession() {

--- a/src/test/java/com/force/api/Account.java
+++ b/src/test/java/com/force/api/Account.java
@@ -1,6 +1,7 @@
 package com.force.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -19,6 +20,7 @@ public class Account {
 	private Double annualRevenue;
 	
 	@JsonProperty("Contacts")
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	List<Contact> contacts;
 	
 	public String getId() {

--- a/src/test/java/com/force/api/BasicCRUDTest.java
+++ b/src/test/java/com/force/api/BasicCRUDTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import org.junit.Test;
 
 /**
@@ -14,19 +13,20 @@ import org.junit.Test;
  */
 public class BasicCRUDTest {
 
-	static final String TEST_NAME = "force-rest-api basic crud test";
+	
 
 	@Test
 	public void basicCRUDTest() {
-
+		final String testName = "force-rest-api basic crud test";
+		
 		ForceApi api = new ForceApi(new ApiConfig()
 			.setUsername(Fixture.get("username"))
 			.setPassword(Fixture.get("password"))
 			.setClientId(Fixture.get("clientId"))
 			.setClientSecret(Fixture.get("clientSecret")));
 
-		if(api.query("SELECT name FROM Account WHERE name LIKE '"+TEST_NAME+"%'",Account.class).getTotalSize()>0) {
-			fail("Looks like org is not clean. Manually delete account record with name '"+TEST_NAME+"' before running this test");
+		if(api.query("SELECT name FROM Account WHERE name LIKE '"+testName+"%'",Account.class).getTotalSize()>0) {
+			fail("Looks like org is not clean. Manually delete account record with name '"+testName+"' before running this test");
 		}
 		
 		try {
@@ -34,7 +34,7 @@ public class BasicCRUDTest {
 			// TEST CREATE
 			
 			Account a = new Account();
-			a.setName(TEST_NAME);
+			a.setName(testName);
 			a.setExternalId("1234");
 			String id = api.createSObject("account", a);
 			assertNotNull(id);
@@ -42,22 +42,22 @@ public class BasicCRUDTest {
 			// TEST GET
 			
 			a = api.getSObject("account", id).as(Account.class);
-			assertEquals(TEST_NAME,a.getName());
+			assertEquals(testName,a.getName());
 			assertEquals("1234", a.getExternalId());
 			
 			// TEST UPDATE
 			
 			a = new Account();
-			a.setName(TEST_NAME+", updated");
+			a.setName(testName+", updated");
 			api.updateSObject("account", id, a);
 			
 			a = api.getSObject("account", id).as(Account.class);
-			assertEquals(TEST_NAME+", updated",a.getName());
+			assertEquals(testName+", updated",a.getName());
 			
 			// TEST UPSERT: UPDATE
 			
 			a = new Account();
-			a.setName(TEST_NAME);
+			a.setName(testName);
 			a.setAnnualRevenue(3141592.65);
 
 			// test that we get expected result
@@ -67,12 +67,12 @@ public class BasicCRUDTest {
 			assertTrue(3141592.65==api.getSObject("account", id).as(Account.class).getAnnualRevenue());
 			
 			// check that there's still only one record with this name
-			assertTrue(1==api.query("SELECT id FROM Account WHERE name = '"+TEST_NAME+"'",Account.class).getTotalSize());
+			assertTrue(1==api.query("SELECT id FROM Account WHERE name = '"+testName+"'",Account.class).getTotalSize());
 			
 			// TEST UPSERT: CREATE
 			
 			a = new Account();
-			a.setName(TEST_NAME+" new one");
+			a.setName(testName+" new one");
 			a.setAnnualRevenue(1414213.56);
 			
 			// test that we get expected result
@@ -83,7 +83,7 @@ public class BasicCRUDTest {
 			
 		}
 		finally {
-			QueryResult<Account> res = api.query("SELECT id FROM Account WHERE name LIKE '"+TEST_NAME+"%'", Account.class);
+			QueryResult<Account> res = api.query("SELECT id FROM Account WHERE name LIKE '"+testName+"%'", Account.class);
 			for(Account a : res.getRecords()) {
 				api.deleteSObject("account", a.getId());
 			}
@@ -91,6 +91,49 @@ public class BasicCRUDTest {
 		
 	}
 	
+	@Test
+	public void basicCRUDTestIncludingNullValues() {
+		final String testName = "force-rest-api basic crud test with nulls";
+		
+		ForceApi api = new ForceApi(new ApiConfig()
+				.setUsername(Fixture.get("username"))
+				.setPassword(Fixture.get("password"))
+				.setClientId(Fixture.get("clientId"))
+				.setClientSecret(Fixture.get("clientSecret"))
+				.setIncludeNullValues(true));
+		
+		if (api.query("SELECT name FROM Account WHERE name LIKE '" + testName + "%'", Account.class).getTotalSize() > 0) {
+			fail("Looks like org is not clean. Manually delete account record with name '" + testName + "' before running this test");
+		}
+		
+		// TEST CREATE
+		
+		Account a = new Account();
+		a.setName(testName);
+		a.setAnnualRevenue(1000.0);
+		a.setExternalId("1234");
+		String id = api.createSObject("account", a);
+		assertNotNull(id);
+		
+		try {
+			// Set a value for name first
+			a = api.getSObject("account", id).as(Account.class);
+			assertEquals(new Double(1000.0), a.getAnnualRevenue());
+			
+			// set annual revenue to a null value
+			Account updatedAccount = new Account();
+			updatedAccount.setName(testName);
+			api.updateSObject("account", id, updatedAccount);
+			
+			Account getAccount = api.getSObject("account", id).as(Account.class);
+			assertEquals(null, getAccount.getAnnualRevenue());
+			
+			
+		} finally {
+			api.deleteSObject("account", id);
+		}
+		
+	}
 	
 	
 }


### PR DESCRIPTION

The default behaviour is still the same as before, i.e. null values are stripped (https://github.com/jesperfj/force-rest-api/compare/master...bb-scout24:master#diff-c3672ea1e5e058c76e450eae4eef97acR16).

Benefit: In the previous state of the library, it was hard to clear existing values because null values were ignored (e.g., clearing a date field never worked).

Downside: Moves some responsibility to think about which values should be nullable and which shouldn't to the user of the library - e.g., Salesforce seems to reject boolean values when they are sent as null. So now the library user needs to take care of ignoring certain null values with Jackson (`@JsonInclude(JsonInclude.Include.NON_NULL)`)