### PR TITLE
Made apiRequest a public method

### DIFF
--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -421,7 +421,7 @@ public class ForceApi {
 		return(session.getApiEndpoint()+"/services/data/"+config.getApiVersionString());
 	}
 	
-	private final HttpResponse apiRequest(HttpRequest req) {
+	public HttpResponse apiRequest(HttpRequest req) {
 		req.setAuthorization("Bearer "+session.getAccessToken());
 		req.setRequestTimeout(this.config.getRequestTimeout());
 		HttpResponse res = Http.send(req);


### PR DESCRIPTION
apiRequest is a very useful method, encapsulating retry logic and
handling explicit HTTP result codes that we don't want to repeat in our
own code.  It would be very helpful to expose it as a public method so
that, for instance, we can pass HTTP headers to SalesForce.