### PR TITLE
Feature upsert

### DIFF
--- a/src/main/java/com/force/api/ApiResponse.java
+++ b/src/main/java/com/force/api/ApiResponse.java
@@ -1,0 +1,33 @@
+package com.force.api;
+
+public class ApiResponse {
+
+	private String id;
+	private ApiError[] errors;
+	private boolean success;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public ApiError[] getErrors() {
+		return errors;
+	}
+
+	public void setErrors(ApiError[] errors) {
+		this.errors = errors;
+	}
+
+	public boolean isSuccess() {
+		return success;
+	}
+
+	public void setSuccess(boolean success) {
+		this.success = success;
+	}
+
+}

--- a/src/main/java/com/force/api/CreateResponse.java
+++ b/src/main/java/com/force/api/CreateResponse.java
@@ -1,27 +1,5 @@
 package com.force.api;
 
-public class CreateResponse {
-	String id;
-	ApiError[] errors;
-	boolean success;
-	public String getId() {
-		return id;
-	}
-	public void setId(String id) {
-		this.id = id;
-	}
-	public ApiError[] getErrors() {
-		return errors;
-	}
-	public void setErrors(ApiError[] errors) {
-		this.errors = errors;
-	}
-	public boolean isSuccess() {
-		return success;
-	}
-	public void setSuccess(boolean success) {
-		this.success = success;
-	}
+public class CreateResponse extends ApiResponse {
 
-	
 }

--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -282,7 +282,7 @@ public class ForceApi {
 	public UpsertResult upsertSObject(String type, String externalIdField, String externalIdValue, Object sObject) {
 		try {
 			String method = externalIdValue != null ? "PATCH" : "POST";
-			String idValue = externalIdValue != null ? "/" + URLEncoder.encode(externalIdValue, "UTF-8") : null;
+			String idValue = externalIdValue != null ? "/" + URLEncoder.encode(externalIdValue, "UTF-8") : "";
 			HttpResponse res =
 					apiRequest(new HttpRequest()
 							.url(uriBase() + "/sobjects/" + type + "/" + externalIdField + idValue)

--- a/src/main/java/com/force/api/UpsertResult.java
+++ b/src/main/java/com/force/api/UpsertResult.java
@@ -1,0 +1,15 @@
+package com.force.api;
+
+
+public class UpsertResult extends ApiResponse {
+
+    private UpsertStatus status;
+
+    public UpsertStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(UpsertStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/force/api/UpsertStatus.java
+++ b/src/main/java/com/force/api/UpsertStatus.java
@@ -1,0 +1,8 @@
+package com.force.api;
+
+public enum UpsertStatus {
+
+    INSERTED,
+    UPDATED
+
+}


### PR DESCRIPTION
This is another improvement to add full support for all features of "upsert" method in Salesforce REST api (https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_upsert.htm). This provides:

1. A notion if a record was created or updated
2. An ID of created/updated record
3. Using "primary" SF ID for upsert (see "Inserting New Records Using Id as the External ID" section).

Thanks,
Vlad