### PR TITLE
ApiSession does not have a method setApiConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ If you already have an access token and endpoint (e.g. from a cookie), you can p
         .setClientSecret("notsolongnumeric"),
 
     ApiSession s = new ApiSession()
-	    .setApiConfig(c)
 	    .setAccessToken("accessToken")
 	    .setApiEndpoint("apiEndpoint");
 


### PR DESCRIPTION
I removed the `.setApiConfig` method call, because the method setApiConfig is undefined for the type ApiSession. It would be redundant anyway, because the configuration `c` is set when instantiating the ForceApi object.