### PR TITLE
added id and instance_url to ApiSession

### DIFF
--- a/src/main/java/com/force/api/ApiSession.java
+++ b/src/main/java/com/force/api/ApiSession.java
@@ -7,6 +7,8 @@ public class ApiSession implements java.io.Serializable {
 	String accessToken;
 	String apiEndpoint;
 	String refreshToken;
+	String instanceUrl;
+	String id;
 
 	public ApiSession() {}
 	
@@ -24,6 +26,12 @@ public class ApiSession implements java.io.Serializable {
 	public String getRefreshToken() {
 		return refreshToken;
 	}
+	public String getInstanceUrl() {
+		return instanceUrl;
+	}
+	public String getId() {
+		return id;
+	}
 	public ApiSession setAccessToken(String accessToken) {
 		this.accessToken = accessToken;
 		return this;
@@ -32,11 +40,17 @@ public class ApiSession implements java.io.Serializable {
 		this.apiEndpoint = apiEndpoint;
 		return this;
 	}
-
 	public ApiSession setRefreshToken(String value) {
 		refreshToken = value;
 		return this;
 	}
-	
+	public ApiSession setInstanceUrl(String value) {
+		instanceUrl = value;
+		return this;
+	}
+	public ApiSession setId(String value) {
+		id = value;
+		return this;
+	}
 
 }

--- a/src/main/java/com/force/api/Auth.java
+++ b/src/main/java/com/force/api/Auth.java
@@ -153,6 +153,8 @@ public class Auth {
 			} else {
 				Map<?, ?> resp = jsonMapper.readValue(r.getStream(), Map.class);
 				return new ApiSession()
+						.setId((String) resp.get("id"))
+						.setInstanceUrl((String) resp.get("instance_url"))
 						.setRefreshToken((String) resp.get("refresh_token"))
 						.setAccessToken((String) resp.get("access_token"))
 						.setApiEndpoint((String) resp.get("instance_url"));
@@ -184,6 +186,8 @@ public class Auth {
 				Map<?, ?> resp = jsonMapper.readValue(r.getStream(), Map.class);
 
 				return new ApiSession()
+						.setId((String) resp.get("id"))
+						.setInstanceUrl((String) resp.get("instance_url"))
 						.setAccessToken((String) resp.get("access_token"))
 						.setApiEndpoint((String) resp.get("instance_url"))
 						.setRefreshToken(refreshToken);


### PR DESCRIPTION
According to https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_understanding_web_server_oauth_flow.htm the `instance_url` and `id` are returned when a request is made for an access token in exchange for an authorization code (your `Auth.completeOAuthWebServerFlow` method that returns an `ApiSession`).

Although not required for further requests to the Force.com REST API, these may be useful in other actions (e.g. directing the user to their connected apps management page, identifying the pod for their instance, identifying and querying for more information about the user, etc.). So it may be useful to expose these rather than lose them.