### PR TITLE
Remove authorisation token from toString representation

### DIFF
--- a/src/main/java/com/force/api/http/HttpRequest.java
+++ b/src/main/java/com/force/api/http/HttpRequest.java
@@ -154,7 +154,7 @@ public class HttpRequest {
 			b.append(h.key+": "+h.value+"\n");
 		}
 		if(authorization!=null) {
-			b.append("Authorization: "+authorization);
+			b.append("Authorization: <hidden for security purpose>");
 		}
 		if(getContentBytes()!=null) {
 			try {


### PR DESCRIPTION
HttpRequest's toString representation should not contain the authorisation token, because then it will be leaked when the request is logged.

This is currently the case - HttpResponse.send method logs the HttpRequest whenever it receives a bad response code from SalesForce, leaking the authorisation code in the log.