### PR TITLE
Do not log full request when bad response code is received

### DIFF
--- a/src/main/java/com/force/api/http/Http.java
+++ b/src/main/java/com/force/api/http/Http.java
@@ -108,7 +108,7 @@ public class Http {
 				// it indicates that SF objects were not changed since the time specified in the "If-Modified-Since" header
 				return new HttpResponse().setResponseCode(code);
 			} else {
-				logger.info("Bad response code: {} on request: {}", code, req.getUrl());
+				logger.info("Bad response code: {} on request: {} {}", code, req.getMethod(), req.getUrl());
 				return new HttpResponse().setString(
 						new String(readResponse(conn.getErrorStream()), "UTF-8")).setResponseCode(code);
 			}

--- a/src/main/java/com/force/api/http/Http.java
+++ b/src/main/java/com/force/api/http/Http.java
@@ -108,7 +108,7 @@ public class Http {
 				// it indicates that SF objects were not changed since the time specified in the "If-Modified-Since" header
 				return new HttpResponse().setResponseCode(code);
 			} else {
-				logger.info("Bad response code: {} on request: {}", code, req);
+				logger.info("Bad response code: {} on request: {}", code, req.getUrl());
 				return new HttpResponse().setString(
 						new String(readResponse(conn.getErrorStream()), "UTF-8")).setResponseCode(code);
 			}


### PR DESCRIPTION
The request object potentially contains sensitive information. For
requests resulting in a bad response code, log only the response code
and the request method and URL.