### PR TITLE
Custom base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,12 @@ This assumes you have an Account class defined with proper Jackson deserializati
 
     QueryResult<Account> res = api.query("SELECT id FROM Account WHERE name LIKE 'Test account%'", Account.class);
 
-### CRUD operations on any path
+### CRUD operations with a custom base path
 
 Sometimes you want to do CRUD operations without the standard `/services/data/<version>` path prefix. To do this you can set a custom base path:
 
     ForceApi api = new ForceApi(myConfig,mySession);
-    api.withBasePath("/").get("/service/apexrest/myApexClass");
+    api.withBasePath("").get("/services/apexrest/myApexClass");
 
 the `withBasePath()` method is shorthand for cloning the ForceApi instance and setting a custom base path with `setCustomBasePath(value)` on the new instance so the original one is kept immutable.
 

--- a/README.md
+++ b/README.md
@@ -162,14 +162,14 @@ This assumes you have an Account class defined with proper Jackson deserializati
 
     QueryResult<Account> res = api.query("SELECT id FROM Account WHERE name LIKE 'Test account%'", Account.class);
 
-### CRUD operations with a custom base path
+### CRUD operations on root path
 
-Sometimes you want to do CRUD operations without the standard `/services/data/<version>` path prefix. To do this you can set a custom base path:
+Sometimes you want to do CRUD operations without the standard `/services/data/<version>` path prefix. To do this you can get a ForceApi instance that uses root path:
 
     ForceApi api = new ForceApi(myConfig,mySession);
-    api.withBasePath("").get("/services/apexrest/myApexClass");
+    api.rootPath().get("/services/apexrest/myApexClass");
 
-the `withBasePath()` method is shorthand for cloning the ForceApi instance and setting a custom base path with `setCustomBasePath(value)` on the new instance so the original one is kept immutable.
+`rootPath()` returns a new ForceApi instance that uses root path for the `get()`, `delete()`, `put()`, `post()`, `patch()` and `request()` methods.
 
 ## Working with API versions
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,15 @@ This assumes you have an Account class defined with proper Jackson deserializati
 
     QueryResult<Account> res = api.query("SELECT id FROM Account WHERE name LIKE 'Test account%'", Account.class);
 
+### CRUD operations on any path
+
+Sometimes you want to do CRUD operations without the standard `/services/data/<version>` path prefix. To do this you can set a custom base path:
+
+    ForceApi api = new ForceApi(myConfig,mySession);
+    api.withBasePath("/").get("/service/apexrest/myApexClass");
+
+the `withBasePath()` method is shorthand for cloning the ForceApi instance and setting a custom base path with `setCustomBasePath(value)` on the new instance so the original one is kept immutable.
+
 ## Working with API versions
 
 You can inspect supported API versions and get more detailed info for each version using `SupportedVersions`:

--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -52,7 +52,7 @@ public class ForceApi {
 	final ApiConfig config;
 	ApiSession session;
 	private boolean autoRenew = false;
-	private customBasePath = null;
+	private String customBasePath = null;
 
 	public ForceApi(ApiConfig config, ApiSession session) {
 		this.config = config;
@@ -490,7 +490,7 @@ public class ForceApi {
 	}
 
 	private final String uriBaseWithCustomPath() {
-		if(customBasePath) {
+		if(customBasePath!=null) {
 			return(session.getApiEndpoint()+customBasePath);
 		} else {
 			return(session.getApiEndpoint()+"/services/data/"+config.getApiVersionString());

--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -52,7 +52,7 @@ public class ForceApi {
 	final ApiConfig config;
 	ApiSession session;
 	private boolean autoRenew = false;
-	private String customBasePath = null;
+    boolean useRootPath = false;
 
 	public ForceApi(ApiConfig config, ApiSession session) {
 		this.config = config;
@@ -79,13 +79,9 @@ public class ForceApi {
 		return session;
 	}
 
-	public void setCustomBasePath(String value) {
-		customBasePath = value;
-	}
-
-	public ForceApi withBasePath(String value) {
+	public ForceApi rootPath() {
 		ForceApi clone = new ForceApi(this.config, this.session);
-		clone.setCustomBasePath(value);
+        clone.useRootPath=true;
 		return clone;
 	}
 
@@ -101,7 +97,7 @@ public class ForceApi {
 	 */
 	public ResourceRepresentation get(String path) {
 		return new ResourceRepresentation(apiRequest(new HttpRequest()
-				.url(uriBaseWithCustomPath()+path)
+				.url(uriBaseOrRoot()+path)
 				.method("GET")
 				.header("Accept", "application/json")),
 				jsonMapper);
@@ -118,7 +114,7 @@ public class ForceApi {
 	 */
 	public ResourceRepresentation delete(String path) {
 		return new ResourceRepresentation(apiRequest(new HttpRequest()
-				.url(uriBaseWithCustomPath() + path)
+				.url(uriBaseOrRoot() + path)
 				.method("DELETE")
 				.header("Accept", "application/json")),
 				jsonMapper);
@@ -161,7 +157,7 @@ public class ForceApi {
 	public ResourceRepresentation request(String method, String path, Object input) {
 		try {
 			return new ResourceRepresentation(apiRequest(new HttpRequest()
-					.url(uriBaseWithCustomPath() + path)
+					.url(uriBaseOrRoot() + path)
 					.method(method)
 					.header("Accept", "application/json")
 					.header("Content-Type", "application/json")
@@ -489,9 +485,9 @@ public class ForceApi {
 		return(session.getApiEndpoint()+"/services/data/"+config.getApiVersionString());
 	}
 
-	private final String uriBaseWithCustomPath() {
-		if(customBasePath!=null) {
-			return(session.getApiEndpoint()+customBasePath);
+	private final String uriBaseOrRoot() {
+		if(useRootPath) {
+			return(session.getApiEndpoint());
 		} else {
 			return(session.getApiEndpoint()+"/services/data/"+config.getApiVersionString());
 		}

--- a/src/test/java/com/force/api/ApexRESTTest.java
+++ b/src/test/java/com/force/api/ApexRESTTest.java
@@ -1,0 +1,34 @@
+package com.force.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+/**
+ * Smoke test covering the basics.
+ * @author jjoergensen
+ *
+ */
+public class ApexRESTTest {
+
+	static final String TEST_NAME = "force-rest-api Apex rest test";
+
+	@Test
+	public void apexRestGetTest() {
+
+		ForceApi api = new ForceApi(new ApiConfig()
+			.setUsername(Fixture.get("username"))
+			.setPassword(Fixture.get("password"))
+			.setClientId(Fixture.get("clientId"))
+			.setClientSecret(Fixture.get("clientSecret")));
+        
+        // TEST GET
+        
+        Account a = api.rootPath().get("/services/apexrest/ApexTest").as(Account.class);
+        System.out.println(a.getName());
+        assertNotNull(a.getName());
+	}
+}


### PR DESCRIPTION
This PR proposes a design for addressing #86. Feedback welcome. The idea is to allow setting a custom base path in `ForceApi`. It is only applicable to the "raw" get/post/put/delete/patch methods and will not affect any other methods in the class. The purpose is to allow this library to be used with Apex REST and maybe other API endpoints outside of the standard `/services/data/<version>` base path.

No tests have been written against this yet. The code compiles and the standard tests pass.

README has details for how this will work. But here it is again:

    ForceApi api = new ForceApi(myConfig,mySession);
    api.withBasePath("").get("/services/apexrest/myApexClass");

@ModeratelyComfortableChair let me know what you think.
