### PR TITLE
Add escaping of username and password in soap login.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
             <version>[2.9.10.3,)</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.9</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
             <version>2.9.0</version>

--- a/src/main/java/com/force/api/Auth.java
+++ b/src/main/java/com/force/api/Auth.java
@@ -18,6 +18,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.force.api.http.Http;
 import com.force.api.http.HttpRequest;
 import com.force.api.http.HttpResponse;
+
+import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,8 +78,8 @@ public class Auth {
 					"              xmlns:env=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"+
 					"    <env:Body>\n"+
 			        "        <n1:login xmlns:n1=\"urn:partner.soap.sforce.com\">\n"+
-			        "            <n1:username>"+c.getUsername()+"</n1:username>\n"+
-			        "            <n1:password>"+c.getPassword()+"</n1:password>\n"+
+			        "            <n1:username>"+StringEscapeUtils.escapeXml10(c.getUsername())+"</n1:username>\n"+
+			        "            <n1:password>"+StringEscapeUtils.escapeXml10(c.getPassword())+"</n1:password>\n"+
 			        "        </n1:login>\n"+
 			        "    </env:Body>\n"+
 			        "</env:Envelope>\n").getBytes("UTF-8");


### PR DESCRIPTION
Username and password are not escaped and this can lead to a 500 on login if it contains certain chars.

The real fix would be to use an XML library, but I'll let you choose on that since it's quite a bigger feature to bring this in.

I didn't find anything to escape xml in the existing dependencies so I imported apache text commons which is quite common in applications so it should not be a big deal for users.  