### PR TITLE
Add settings for proxy with authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ If you already have an access token and endpoint (e.g. from a cookie), you can p
 
     ForceApi api = new ForceApi(c,s);
 
+### Instantiate with proxy
+
+    ForceApi api = new ForceApi(new ApiConfig()
+        .setProxyHost("127.0.0.1")
+        .setProxyPort(8080)
+        .setProxyUsername("proxy-user")
+        .setProxyPassword("proxy-password"));
+
+
 ## CRUD and Query Operations
 
 ### Get an SObject

--- a/pom.xml
+++ b/pom.xml
@@ -176,8 +176,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>9</source>
+                    <target>9</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -68,11 +68,11 @@ public class ForceApi {
 	}
 
 	public ForceApi(ApiConfig apiConfig) {
+		System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "");
 		config = apiConfig;
 		jsonMapper = config.getObjectMapper();
 		session = Auth.authenticate(apiConfig);
 		autoRenew  = true;
-
 	}
 
 	public ApiSession getSession() {
@@ -496,7 +496,7 @@ public class ForceApi {
 	private final HttpResponse apiRequest(HttpRequest req) {
 		req.setAuthorization("Bearer "+session.getAccessToken());
 		req.setRequestTimeout(this.config.getRequestTimeout());
-		HttpResponse res = Http.send(req);
+		HttpResponse res = Http.send(req, this.config.getProxySettings());
 		if(res.getResponseCode()==401) {
 			// Perform one attempt to auto renew session if possible
 			if (autoRenew) {
@@ -510,7 +510,7 @@ public class ForceApi {
 					config.getSessionRefreshListener().sessionRefreshed(session);
 				}
 				req.setAuthorization("Bearer "+session.getAccessToken());
-				res = Http.send(req);
+				res = Http.send(req, this.config.getProxySettings());
 			}
 		}
 		// 304 is a special case when the "If-Modified-Since" header is used, it is not an error,

--- a/src/main/java/com/force/api/ProxySettings.java
+++ b/src/main/java/com/force/api/ProxySettings.java
@@ -1,0 +1,22 @@
+package com.force.api;
+
+import java.net.Authenticator;
+import java.net.Proxy;
+
+public class ProxySettings {
+    private final Proxy proxy;
+    private final Authenticator proxyAuthenticator;
+
+    ProxySettings(Proxy proxy, Authenticator proxyAuthenticator) {
+        this.proxy = proxy;
+        this.proxyAuthenticator = proxyAuthenticator;
+    }
+
+    public Proxy getProxy() {
+        return proxy;
+    }
+
+    public Authenticator getProxyAuthenticator() {
+        return proxyAuthenticator;
+    }
+}

--- a/src/main/java/com/force/api/http/Http.java
+++ b/src/main/java/com/force/api/http/Http.java
@@ -1,5 +1,6 @@
 package com.force.api.http;
 
+import com.force.api.ProxySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -8,11 +9,7 @@ import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.*;
 
 
 public class Http {
@@ -60,9 +57,14 @@ public class Http {
 		return bout.toByteArray();
 	}
 
-	public static final HttpResponse send(HttpRequest req) {
+	public static final HttpResponse send(HttpRequest req, ProxySettings proxySettings) {
 		try {
-			HttpURLConnection conn = (HttpURLConnection) new URL(req.getUrl()).openConnection();
+			URL url = new URL(req.getUrl());
+			Proxy proxy = proxySettings.getProxy();
+			HttpURLConnection conn = (HttpURLConnection) (proxy == null ? url.openConnection() : url.openConnection(proxy));
+			if(proxy != null && proxySettings.getProxyAuthenticator() != null) {
+				conn.setAuthenticator(proxySettings.getProxyAuthenticator());
+			}
 			if(req.getRequestTimeout()>0){
 				conn.setConnectTimeout(req.getRequestTimeout());
 				conn.setReadTimeout(req.getRequestTimeout());


### PR DESCRIPTION
In enterprise companies, proxies might be neeed to talk to foreign websites.
This pull request adds proxy settings in the current library. Furthermore it allows user + password protected proxies.